### PR TITLE
mk: use mingw-w64 x86_64, pthreads support and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ LIBS	:= -lrem -lssl -lcrypto -lwsock32 -lws2_32 -liphlpapi -lwinmm \
 	-lstrmiids -lole32 -loleaut32 -static -lstdc++ -lpthread
 
 
-COMMON_FLAGS := -j4 CC=$(CC) \
+COMMON_FLAGS := CC=$(CC) \
 		CXX=$(CXX) \
 		RANLIB=$(RANLIB) \
 		EXTRA_CFLAGS="$(CFLAGS)" \
@@ -124,7 +124,7 @@ openssl:
 	cd openssl && \
 		CC=$(CC) RANLIB=$(RANLIB) AR=$(AR) \
 		./Configure mingw64 $(OPENSSL_FLAGS) && \
-		make -j4 build_libs
+		make build_libs
 
 clean:
 	make distclean -C baresip

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,9 @@ COMMON_FLAGS := CC=$(CC) \
 		EXTRA_CFLAGS="$(CFLAGS)" \
 		EXTRA_LFLAGS="$(LFLAGS)" \
 		LIBS="$(LIBS)" \
-		SYSROOT=$(SYSROOT)
+		SYSROOT=$(SYSROOT) \
+		RELEASE=1 \
+		OS=win32
 
 EXTRA_MODULES := \
 	aubridge \
@@ -99,23 +101,23 @@ default:	retest baresip
 
 libre.a: Makefile
 	@rm -f re/libre.*
-	make $@ -C re $(COMMON_FLAGS)
+	$(MAKE) $@ -C re $(COMMON_FLAGS)
 
 librem.a:	Makefile libre.a
 	@rm -f rem/librem.*
-	@make $@ -C rem $(COMMON_FLAGS)
+	$(MAKE) $@ -C rem $(COMMON_FLAGS)
 
 .PHONY: retest
 retest:		Makefile librem.a libre.a
 	@rm -f retest/retest.exe
-	make -C retest $(COMMON_FLAGS) LIBRE_SO=$(PWD)/re \
+	$(MAKE) -C retest $(COMMON_FLAGS) LIBRE_SO=$(PWD)/re \
 		LIBREM_PATH=$(PWD)/rem
 
 .PHONY: baresip
 baresip:	Makefile librem.a libre.a
 	@rm -f baresip/baresip.exe baresip/src/static.c
 	PKG_CONFIG_LIBDIR="$(SYSROOT)/lib/pkgconfig" \
-	make selftest.exe baresip.exe -C baresip $(COMMON_FLAGS) STATIC=1 \
+	$(MAKE) selftest.exe baresip.exe -C baresip $(COMMON_FLAGS) STATIC=1 \
 		LIBRE_SO=$(PWD)/re LIBREM_PATH=$(PWD)/rem \
 		EXTRA_MODULES="$(EXTRA_MODULES)"
 
@@ -124,7 +126,7 @@ openssl:
 	cd openssl && \
 		CC=$(CC) RANLIB=$(RANLIB) AR=$(AR) \
 		./Configure mingw64 $(OPENSSL_FLAGS) && \
-		make build_libs
+		$(MAKE) build_libs
 
 clean:
 	make distclean -C baresip
@@ -133,7 +135,7 @@ clean:
 	make distclean -C re
 
 info:
-	make $@ -C re $(COMMON_FLAGS)
+	$(MAKE) $@ -C re $(COMMON_FLAGS)
 
 dump:
 	@echo "TUPLE = $(TUPLE)"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 
 #
-# To build with 64-bit toolchain:
+# To build with 32-bit toolchain:
 #
 # make TUPLE=i686-w64-mingw32
 #
@@ -14,10 +14,10 @@
 OS        := $(shell uname -s | tr "[A-Z]" "[a-z]")
 
 ifeq ($(OS),linux)
-	TUPLE   := i686-w64-mingw32
+	TUPLE   := x86_64-w64-mingw32
 endif
 ifeq ($(OS),darwin)
-	TUPLE	:= i686-w64-mingw32
+	TUPLE	:= x86_64-w64-mingw32
 endif
 
 
@@ -48,32 +48,16 @@ LFLAGS    := \
 # workaround for linker order (note, the order is important)
 LIBS	:= -lrem -lssl -lcrypto -lwsock32 -lws2_32 -liphlpapi -lwinmm \
 	-lgdi32 -lcrypt32 \
-	-lstrmiids -lole32 -loleaut32 -static -lstdc++
+	-lstrmiids -lole32 -loleaut32 -static -lstdc++ -lpthread
 
 
-COMMON_FLAGS := CC=$(CC) \
+COMMON_FLAGS := -j4 CC=$(CC) \
 		CXX=$(CXX) \
 		RANLIB=$(RANLIB) \
 		EXTRA_CFLAGS="$(CFLAGS)" \
 		EXTRA_LFLAGS="$(LFLAGS)" \
 		LIBS="$(LIBS)" \
-		SYSROOT=$(SYSROOT) \
-		SYSROOT_ALT= \
-		RELEASE=1 \
-		HAVE_GETOPT=1 \
-		HAVE_LIBRESOLV= \
-		HAVE_RESOLV= \
-		HAVE_PTHREAD= \
-		HAVE_PTHREAD_RWLOCK= \
-		HAVE_LIBPTHREAD= \
-		HAVE_INET6=1 \
-		PEDANTIC= \
-		OPT_SIZE= \
-		OS=win32 \
-		USE_OPENSSL=yes \
-		USE_OPENSSL_DTLS=yes \
-		USE_OPENSSL_SRTP=yes \
-		USE_ZLIB=
+		SYSROOT=$(SYSROOT)
 
 EXTRA_MODULES := \
 	aubridge \
@@ -122,12 +106,10 @@ librem.a:	Makefile libre.a
 	@make $@ -C rem $(COMMON_FLAGS)
 
 .PHONY: retest
-test: retest
 retest:		Makefile librem.a libre.a
 	@rm -f retest/retest.exe
 	make -C retest $(COMMON_FLAGS) LIBRE_SO=$(PWD)/re \
 		LIBREM_PATH=$(PWD)/rem
-	cd retest && $(WINE) retest -r
 
 .PHONY: baresip
 baresip:	Makefile librem.a libre.a
@@ -136,14 +118,13 @@ baresip:	Makefile librem.a libre.a
 	make selftest.exe baresip.exe -C baresip $(COMMON_FLAGS) STATIC=1 \
 		LIBRE_SO=$(PWD)/re LIBREM_PATH=$(PWD)/rem \
 		EXTRA_MODULES="$(EXTRA_MODULES)"
-	cd baresip && $(WINE) selftest.exe && cd ..
 
 .PHONY: openssl
 openssl:
 	cd openssl && \
 		CC=$(CC) RANLIB=$(RANLIB) AR=$(AR) \
-		./Configure mingw $(OPENSSL_FLAGS) && \
-		make build_libs
+		./Configure mingw64 $(OPENSSL_FLAGS) && \
+		make -j4 build_libs
 
 clean:
 	make distclean -C baresip
@@ -157,3 +138,8 @@ info:
 dump:
 	@echo "TUPLE = $(TUPLE)"
 	@echo "WINE  = $(WINE)"
+
+.PHONY: test
+test: retest baresip
+	cd retest && $(WINE) retest -r
+	cd baresip && $(WINE) selftest.exe

--- a/README.md
+++ b/README.md
@@ -1,36 +1,34 @@
 # baresip-win32
-Baresip cross-compiled for Windows using Mingw
+Baresip cross-compiled for Windows using MinGW-w64
 
 
 ## Tools to install
 
-You need to install the Mingw32-compiler and Wine:
+You need to install the MinGW-w64 compiler and Wine:
 
-Debian:
+Debian/Ubuntu:
 
 ```bash
-sudo apt-get install mingw32 wine
+sudo apt-get install mingw-w64 wine
 ```
 
-OSX Using Macports:
+macOS using Homebrew:
 
 ```bash
-sudo port install i386-mingw32-gcc wine
+brew install mingw-w64 wine
 ```
 
 ## Copy the source code
 
 ```bash
-$ wget https://github.com/baresip/re/archive/v1.1.0.tar.gz
-$ wget https://github.com/baresip/rem/archive/v0.6.0.tar.gz
-$ wget https://github.com/baresip/baresip/archive/v1.0.0.tar.gz
-$ wget https://www.openssl.org/source/openssl-1.1.0e.tar.gz
-
-$ git clone https://github.com/baresip/retest.git
+$ git clone https://github.com/baresip/re
+$ git clone https://github.com/baresip/rem
+$ git clone https://github.com/baresip/retest
+$ git clone https://github.com/baresip/baresip
+$ wget https://www.openssl.org/source/openssl-1.1.1m.tar.gz
+$ tar -xf openssl-1.1.1m.tar.gz
+$ mv openssl-1.1.1m openssl
 ```
-
-... and unpack in the root directory.
-
 
 ## Cross-Compile the projects
 


### PR DESCRIPTION
Since microsoft has discontinued 32-bit, the default build should be 64-bit.

Furthermore we can optimize the CFLAGS, because libre has now a better
detection regarding cross compilation (CC_TEST).

mingw-w64 supports winpthreads by default.