### PR TITLE
cmake: set CMAKE_SYSTEM_PROCESSOR variable

### DIFF
--- a/cmake/mingw-w64-x86_64.cmake
+++ b/cmake/mingw-w64-x86_64.cmake
@@ -5,6 +5,7 @@
 #    *) cd build
 #    *) cmake -DCMAKE_TOOLCHAIN_FILE=~/mingw-w64-x86_64.cmake ..
 
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
 set(CMAKE_SYSTEM_NAME Windows)
 set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
 


### PR DESCRIPTION
set the ARCH variable to avoid an empty string here:

```
retest: libre version 2.7.0 (/Windows)
```

@sreimers please merge